### PR TITLE
Remove TRANSITION mode

### DIFF
--- a/makefile
+++ b/makefile
@@ -96,7 +96,6 @@ $(LIBRARY): $(OBJS)
 ./model/nh_utils.o : ./model/nh_utils.F90
 	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHER_FFLAGS) $(FAST) -c $< -o $@
 
-# For PROD/TRANSITION, this is overwritten below
 ./model/fv_mapz.o : ./model/fv_mapz.F90
 	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHER_FFLAGS) $(FAST) -c $< -o $@
 
@@ -106,20 +105,6 @@ $(LIBRARY): $(OBJS)
 # additional include files (ESMF_INC) needed for PGI
 ./driver/fvGFS/atmosphere.o : ./driver/fvGFS/atmosphere.F90
 	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS) $(OTHER_FFLAGS) $(ESMF_INC) -c $< -o $@
-
-# For CCPP acceptance: reduce optimization for certain files to
-# obtain bit-for-bit identical results in PROD mode on Theia/Intel 15
-ifneq (,$(findstring TRANSITION,$(CPPDEFS)))
-FFLAGS_LOPT=$(subst CORE-AVX2,CORE-AVX-I,\
-              $(subst no-prec-div,prec-div,\
-                $(subst no-prec-sqrt,prec-sqrt,$(FFLAGS))))
-./model/dyn_core.o : ./model/dyn_core.F90
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS_LOPT) $(OTHER_FFLAGS) -c $< -o $@
-./model/fv_mapz.o : ./model/fv_mapz.F90
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS_LOPT) $(OTHER_FFLAGS) $(FAST) -c $< -o $@
-./model/fv_cmp.o : ./model/fv_cmp.F90
-	$(FC) $(CPPDEFS) $(FPPFLAGS) $(FFLAGS_LOPT) $(OTHER_FFLAGS) -c $< -o $@
-endif # (,$(findstring TRANSITION,$(CPPDEFS)))
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Changes:

- remove all code related to the deprecated TRANSITION mode for Theia+Intel15, affects makefile and model/fv_mapz.F90

For regression testing, see NCAR/NEMSfv3gfs#251