### PR TITLE
Bugfix for GNU compiler in makefile, add missing include statement

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,7 +23,7 @@ endif
 
 LIBRARY  = libfv3core.a
 
-FFLAGS   += -I$(FMS_DIR) -I../gfsphysics -I../ipd -I../io
+FFLAGS   += -I$(FMS_DIR) -I../gfsphysics -I../ipd -I../io -I.
 
 SRCS_f   =
 


### PR DESCRIPTION
This PR adds a missing include statement to the top-level include file, required for the GNU compiler.

This has been tested on Cheyenne (where the problem occurred), including regression testing for both Intel and GNU, and can be merged immediately.