### PR TITLE
Update dtc/develop from NOAA-EMC dev/emc 2020/07/07

### DIFF
--- a/tools/fv_diagnostics.F90
+++ b/tools/fv_diagnostics.F90
@@ -5572,7 +5572,7 @@ end subroutine eqv_pot
    real, intent(in):: grav, zvir, z_bot, z_top
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt
    real, intent(in), dimension(is:ie,js:je,km):: vort
-   real, intent(in):: delz(is-ng:ie+ng,js-ng:je+ng,km)
+   real, intent(in):: delz(is:ie,js:je,km)
    real, intent(in):: q(is-ng:ie+ng,js-ng:je+ng,km,*)
    real, intent(in):: phis(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in):: peln(is:ie,km+1,js:je)
@@ -5630,7 +5630,7 @@ end subroutine eqv_pot
    real, intent(in):: grav, zvir, z_bot, z_top
    real, intent(in), dimension(is-ng:ie+ng,js-ng:je+ng,km):: pt, w
    real, intent(in), dimension(is:ie,js:je,km):: vort
-   real, intent(in):: delz(is-ng:ie+ng,js-ng:je+ng,km)
+   real, intent(in):: delz(is:ie,js:je,km)
    real, intent(in):: q(is-ng:ie+ng,js-ng:je+ng,km,*)
    real, intent(in):: phis(is-ng:ie+ng,js-ng:je+ng)
    real, intent(in):: peln(is:ie,km+1,js:je)


### PR DESCRIPTION
This PR updates dtc/develop from NOAA-EMC dev/emc, which contains:
- updates from GSL physics merge (bugfixes for fv3 dycore)
- fix for multi_gases to 32 bit compiling

Associated PRs:

https://github.com/NCAR/ufs-weather-model/pull/59
https://github.com/NCAR/fv3atm/pull/58
https://github.com/NCAR/ccpp-physics/pull/468
https://github.com/NCAR/ccpp-framework/pull/310
https://github.com/NCAR/GFDL_atmos_cubed_sphere/pull/15

For regression testing information, see https://github.com/NCAR/ufs-weather-model/pull/59
