### PR TITLE
FA in fv_regional_bc and external_ic

### DIFF
--- a/model/fv_dynamics.F90
+++ b/model/fv_dynamics.F90
@@ -779,11 +779,18 @@ contains
         if (is_master()) write(*,'(A, I3, A1, I3)') 'finished k_split ', n_map, '/', k_split
        call prt_mxm('T_dyn_a3',    pt, is, ie, js, je, ng, npz, 1., gridstruct%area_64, domain)
        call prt_mxm('SPHUM_dyn',   q(isd,jsd,1,sphum  ), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('liq_wat_dyn', q(isd,jsd,1,liq_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('rainwat_dyn', q(isd,jsd,1,rainwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       call prt_mxm('ice_wat_dyn', q(isd,jsd,1,ice_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       !call prt_mxm('snowwat_dyn', q(isd,jsd,1,snowwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
-       !call prt_mxm('graupel_dyn', q(isd,jsd,1,graupel), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if ( liq_wat > 0 )  &
+         call prt_mxm('liq_wat_dyn', q(isd,jsd,1,liq_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if ( rainwat > 0 )  &
+         call prt_mxm('rainwat_dyn', q(isd,jsd,1,rainwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if ( ice_wat > 0 )  &
+         call prt_mxm('ice_wat_dyn', q(isd,jsd,1,ice_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if ( snowwat > 0 )  &
+         call prt_mxm('snowwat_dyn', q(isd,jsd,1,snowwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if ( graupel > 0 )  &
+         call prt_mxm('graupel_dyn', q(isd,jsd,1,graupel), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)
+       if ( q_rimef > 0 )  &
+         call prt_mxm('q_rimef_dyn', q(isd,jsd,1,q_rimef), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)       
      endif
 #ifdef AVEC_TIMERS
                                                   call avec_timer_stop(6)
@@ -930,7 +937,6 @@ contains
        call prt_mxm('liq_wat_dyn', q(isd,jsd,1,liq_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)              
        call prt_mxm('rainwat_dyn', q(isd,jsd,1,rainwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)              
        call prt_mxm('ice_wat_dyn', q(isd,jsd,1,ice_wat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)              
-!       call prt_mxm('snowwat_dyn', q(isd,jsd,1,snowwat), is, ie, js, je, ng, npz, 1.,gridstruct%area_64, domain)              
      endif                                                                                                                    
   endif                                                                                                                       
 

--- a/model/fv_sg.F90
+++ b/model/fv_sg.F90
@@ -1941,7 +1941,9 @@ contains
  integer, intent(in):: is, ie, js, je, ng, kbot
  logical, intent(in):: hydrostatic
  real,    intent(in):: dp(is-ng:ie+ng,js-ng:je+ng,kbot)  !< total delp-p
- real,    intent(in):: delz(is-ng:,js-ng:,1:)
+ !mzhang: bug
+ !real,    intent(in):: delz(is-ng:,js-ng:,1:)
+ real, intent(in):: delz(is:,js:,1:)
  real,    intent(in):: peln(is:ie,kbot+1,js:je)           !< ln(pe)
  logical, intent(in), OPTIONAL :: check_negative
  real,    intent(inout), dimension(is-ng:ie+ng,js-ng:je+ng,kbot)::    &
@@ -2167,7 +2169,7 @@ contains
         ql(i,j,k) = ql2(i,j)
         qi(i,j,k) = qi2(i,j)
         if (present(qs)) then
-        qs(i,j,k) = qs2(i,j)
+           qs(i,j,k) = qs2(i,j)
         endif
         qr(i,j,k) = qr2(i,j)
         pt(i,j,k) = pt2(i,j)

--- a/tools/external_ic.F90
+++ b/tools/external_ic.F90
@@ -570,8 +570,9 @@ contains
 
 !--- read in the number of tracers in the NCEP NGGPS ICs
       call read_data ('INPUT/'//trim(fn_gfs_ctl), 'ntrac', ntrac, no_domain=.TRUE.)
-      if (ntrac > ntracers) call mpp_error(FATAL,'==> External_ic::get_nggps_ic: more NGGPS tracers &
-                                 &than defined in field_table '//trim(fn_gfs_ctl)//' for NGGPS IC')
+!mzhang: not in FA
+!      if (ntrac > ntracers) call mpp_error(FATAL,'==> External_ic::get_nggps_ic: more NGGPS tracers &
+!                                 &than defined in field_table '//trim(fn_gfs_ctl)//' for NGGPS IC')
 
 !
       call get_data_source(source,Atm%flagstruct%regional)


### PR DESCRIPTION
This PR focus on two topics: 
-  In fv_regional_bc: initialize q_rimef and add the cloud physics auto conversion routine for FA scheme.
 - Fix the ntrac> ntracers limitation in external_ic.
- Add temperature rebalance in the last step of Lagrangian_to_Eulerian step
- Fix a delz bug in subroutine neg_adj2
 - Further optimize the use of q_rimef in fv_dynamic

Full RTs passed except fv3_ccpp_gfdlmp_hwrfsas generated non-bit4bit results due to a known fix in CCPP HWRF physics.